### PR TITLE
Be explicit about tran depending upon dparser

### DIFF
--- a/RxODE/src/Makefile
+++ b/RxODE/src/Makefile
@@ -14,7 +14,7 @@ libdparse:
 	echo "make libdparse.a in dparser/ ..."
 	(cd dparser; $(MAKE) -f Makefile.org CC="$(CC)" CFLAGS="$(CFLAGS)" libdparse.a)
 
-libtran:
+libtran: libdparse
 	echo "make tran ..."
 	($(CC) tran*.c -Idparser -Ldparser -ldparse -o tran.exe)
 

--- a/RxODE/src/Makefile.win
+++ b/RxODE/src/Makefile.win
@@ -14,7 +14,7 @@ libdparse:
 	echo "make libodeaux.a ..."
 	(cd dparser; $(MAKE) -f Makefile.org CC="$(CC)" CFLAGS="$(CFLAGS)" libdparse.a)
 
-libtran:
+libtran: libdparse
 	echo "make tran ..."
 	($(CC) tran*.c -Idparser -Ldparser -ldparse -o tran.exe)
 


### PR DESCRIPTION
This allows the use of `MAKEFLAGS="-j 4"` for parallel make.